### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           release_name: ${{ github.ref }}
       
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ghcr.io/ermakov-oleg/serverless-registry-proxy
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore